### PR TITLE
Update bot to support Ruby 2.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,12 +38,6 @@ Lint/DeprecatedClassMethods:
 Lint/EndAlignment:
   Enabled: false
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Lint/UnusedBlockArgument:
-  Exclude:
-    - 'rawrbot.rb'
-
 # Offense count: 4
 # Cop supports --auto-correct.
 Lint/UnusedMethodArgument:
@@ -133,7 +127,6 @@ Style/DeprecatedHashMethods:
   Exclude:
     - 'plugins/SendSignal.rb'
     - 'plugins/Twitter.rb'
-    - 'rawrbot.rb'
 
 # Offense count: 10
 # Configuration parameters: Exclude.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.2.4
 script: bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '1.9.3'
+ruby '2.2.4'
 gem 'cinch', '2.2.4'
 gem 'ffi'
 gem 'rspec'


### PR DESCRIPTION
`bot.quit` joins threads, and joining threads from inside a signal trap can cause deadlocks, so Ruby 2.x forbids it. https://bugs.ruby-lang.org/issues/6416

This puts the `bot.quit` within yet another thread so the bot effectively quits asynchronously. Ruby is OK with that, so we can start using newer Ruby versions! \o/

Closes #11 