### PR TITLE
Fix Karma value tests

### DIFF
--- a/spec/Karma_spec.rb
+++ b/spec/Karma_spec.rb
@@ -289,47 +289,47 @@ RSpec.describe 'Karma' do
     end
   end
 
-  [-9999, -4, 32, 10601].each do |val|
-    context "key has an existing karma value of #{val}" do
+  [-9999, -4, 32, 10601].each do |karma_value|
+    context "key has an existing karma value of #{karma_value}" do
       context 'with a single-word key' do
         let(:karma_key) { 'imatestkey' }
 
         before(:each) do
-          set_db_key_value(karma_key, val)
+          set_db_key_value(karma_key, karma_value)
         end
 
         it 'shows existing karma value' do
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value}."
         end
         it 'shows karma as 1 more after incrementing' do
           msg = make_message(@bot, "#{karma_key}++", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val + 1}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value + 1}."
         end
         it 'shows karma as 2 more after incrementing twice in one line' do
           msg = make_message(@bot, "#{karma_key}++ #{karma_key}++", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val + 2}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value + 2}."
         end
         it 'shows karma as 1 fewer after decrementing' do
           msg = make_message(@bot, "#{karma_key}--", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val - 1}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value - 1}."
         end
         it 'shows karma as 2 fewer after decrementing twice in one line' do
           msg = make_message(@bot, "#{karma_key}-- #{karma_key}--", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val - 2}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value - 2}."
         end
       end
 
@@ -337,41 +337,41 @@ RSpec.describe 'Karma' do
         let(:karma_key) { 'multi word key' }
 
         before(:each) do
-          set_db_key_value(karma_key, val)
+          set_db_key_value(karma_key, karma_value)
         end
 
         it 'shows existing karma value' do
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value}."
         end
         it 'shows karma as 1 more after incrementing' do
           msg = make_message(@bot, "(#{karma_key})++", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val + 1}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value + 1}."
         end
         it 'shows karma as 2 more after incrementing twice in one line' do
           msg = make_message(@bot, "(#{karma_key})++ (#{karma_key})++", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val + 2}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value + 2}."
         end
         it 'shows karma as 1 fewer after decrementing' do
           msg = make_message(@bot, "(#{karma_key})--", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val - 1}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value - 1}."
         end
         it 'shows karma as 2 fewer after decrementing twice in one line' do
           msg = make_message(@bot, "(#{karma_key})-- (#{karma_key})--", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val - 2}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value - 2}."
         end
       end
     end

--- a/spec/Karma_spec.rb
+++ b/spec/Karma_spec.rb
@@ -16,9 +16,7 @@ RSpec.describe 'Karma' do
   let(:table) { 'karma' }
 
   before(:each) do
-    @bot = make_bot
-    @bot.loggers.level = :error
-    @bot.plugins.register_plugin(Karma)
+    @bot = new_bot_with_plugins(Karma)
     @db = KeyValueDatabase::SQLite.new(db_file) do |config|
       config.key_type = String
       config.value_type = Integer
@@ -293,47 +291,46 @@ RSpec.describe 'Karma' do
 
   context 'key has an existing karma value that is not 1 or -1' do
     [-9999, -4, 32, 10601].each do |val|
-      let(:karma_value) { val }
 
       context 'with a single-word key' do
         let(:karma_key) { 'imatestkey' }
 
         before(:each) do
-          set_db_key_value(karma_key, karma_value)
+          set_db_key_value(karma_key, val)
         end
 
-        it 'shows existing karma value' do
+        it "shows existing karma value of #{val}" do
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val}."
         end
-        it 'shows karma as 1 more after incrementing' do
+        it "shows karma as 1 more after incrementing #{val}" do
           msg = make_message(@bot, "#{karma_key}++", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value + 1}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val + 1}."
         end
         it 'shows karma as 2 more after incrementing twice in one line' do
           msg = make_message(@bot, "#{karma_key}++ #{karma_key}++", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value + 2}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val + 2}."
         end
         it 'shows karma as 1 fewer after decrementing' do
           msg = make_message(@bot, "#{karma_key}--", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value - 1}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val - 1}."
         end
         it 'shows karma as 2 fewer after decrementing twice in one line' do
           msg = make_message(@bot, "#{karma_key}-- #{karma_key}--", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value - 2}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val - 2}."
         end
       end
 
@@ -341,41 +338,41 @@ RSpec.describe 'Karma' do
         let(:karma_key) { 'multi word key' }
 
         before(:each) do
-          set_db_key_value(karma_key, karma_value)
+          set_db_key_value(karma_key, val)
         end
 
         it 'shows existing karma value' do
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val}."
         end
         it 'shows karma as 1 more after incrementing' do
           msg = make_message(@bot, "(#{karma_key})++", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value + 1}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val + 1}."
         end
         it 'shows karma as 2 more after incrementing twice in one line' do
           msg = make_message(@bot, "(#{karma_key})++ (#{karma_key})++", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value + 2}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val + 2}."
         end
         it 'shows karma as 1 fewer after decrementing' do
           msg = make_message(@bot, "(#{karma_key})--", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value - 1}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val - 1}."
         end
         it 'shows karma as 2 fewer after decrementing twice in one line' do
           msg = make_message(@bot, "(#{karma_key})-- (#{karma_key})--", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
-          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{karma_value - 2}."
+          expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val - 2}."
         end
       end
     end

--- a/spec/Karma_spec.rb
+++ b/spec/Karma_spec.rb
@@ -289,9 +289,8 @@ RSpec.describe 'Karma' do
     end
   end
 
-  context 'key has an existing karma value that is not 1 or -1' do
-    [-9999, -4, 32, 10601].each do |val|
-
+  [-9999, -4, 32, 10601].each do |val|
+    context "key has an existing karma value of #{val}" do
       context 'with a single-word key' do
         let(:karma_key) { 'imatestkey' }
 
@@ -299,12 +298,12 @@ RSpec.describe 'Karma' do
           set_db_key_value(karma_key, val)
         end
 
-        it "shows existing karma value of #{val}" do
+        it 'shows existing karma value' do
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')
           expect(get_replies(msg).length).to eq 1
           expect(get_replies(msg)[0].text).to eq "#{karma_key} has karma of #{val}."
         end
-        it "shows karma as 1 more after incrementing #{val}" do
+        it 'shows karma as 1 more after incrementing' do
           msg = make_message(@bot, "#{karma_key}++", channel: '#testchan')
           expect(get_replies(msg).length).to eq 0
           msg = make_message(@bot, "!karma #{karma_key}", channel: '#testchan')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,15 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..'))
 require 'cinch'
 require 'cinch/test'
 
+def new_bot_with_plugins(*plugins)
+  bot = make_bot
+  bot.loggers.level = :error
+  plugins.each do |plugin|
+    bot.plugins.register_plugin(plugin)
+  end
+  bot
+end
+
 RSpec.configure do |config|
   config.include(Cinch::Test)
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
The tests weren't actually running using the different karma values; only the last one in the array. This fixes that.

Also pulled out the bot creation into a method for use later in other tests.