### PR TITLE
Learn entries with the prefix in them

### DIFF
--- a/rawrbot.rb
+++ b/rawrbot.rb
@@ -29,7 +29,7 @@ bot = Cinch::Bot.new do
     config.realname = config_hash['realname']
     config.user = config_hash['user']
     config.plugins.plugins = plugins
-    config.plugins.prefix = config_hash['prefix']
+    config.plugins.prefix = /^#{config_hash['prefix']}/
   end
 
   # Authenticate with NickServ.

--- a/spec/unit/Learning_spec.rb
+++ b/spec/unit/Learning_spec.rb
@@ -35,11 +35,11 @@ describe 'Learning' do
   let(:db_file) {'test_learning.sqlite3'}
   let(:table) {'learning'}
   let(:bot_nick) {'testbot'}
-
+  let(:prefix) { /^!/ }
   before(:each) do
     @bot = new_bot_with_plugins(Learning)
     @bot.set_nick(bot_nick)
-    @bot.config.prefix = '!'
+    @bot.config.plugins.prefix = prefix
     @db = KeyValueDatabase::SQLite.new(db_file) do |config|
       config.table = table
     end
@@ -90,6 +90,15 @@ describe 'Learning' do
       replies = get_replies_to("#{bot_nick}: #{key}")
       expect(replies.length).to eq 1
       expect(replies.first.text).to eq("#{key} is #{value}.")
+    end
+
+    it 'should be able to learn an entry with the configured prefix in it' do
+      replies = get_replies_to("#{bot_nick}: #{key} is #{prefix}#{value}")
+      expect(replies.length).to eq 1
+      expect(replies.first).to be_an_acknowledgement
+      replies = get_replies_to("#{bot_nick}: #{key}")
+      expect(replies.length).to eq 1
+      expect(replies.first.text).to eq("#{key} is #{prefix}#{value}.")
     end
   end
 


### PR DESCRIPTION
This fixes a bug where rawrbot's learning plugin was unable to store entries that had the bot plugin prefix in them. I was loading the prefix into the configuration incorrectly so it only checked if the prefix was in the
message, when it should have checked if it was at the beginning of the line.

Also, tests were configuring the prefix incorrectly, so the mock bot wasn't respecting that configuration option. That's fixed as well.