### PR TITLE
Fix GoogleRSS plugin error

### DIFF
--- a/config/samples/config.yml
+++ b/config/samples/config.yml
@@ -38,4 +38,4 @@ admins: ['mynick']
 
 # List of plugins (the names of Classes defined in the plugin files)
 # to load when the bot is started.
-plugins: [Social,Messenger,Karma,Learning,SendSignal,GoogleRSS]
+plugins: [Social,Messenger,Karma,Learning,SendSignal]


### PR DESCRIPTION
When attempting to run rawrbot, an error occurs with the GoogleRSS plugin. Removing this plugin from the plugin list in the config file resolved this error.